### PR TITLE
ページ毎にキーフレームを強制

### DIFF
--- a/colab/vrc_lt_converter.ipynb
+++ b/colab/vrc_lt_converter.ipynb
@@ -97,9 +97,9 @@
         "mp4_file_name = base_file_name + \".\" + str(output_resolution_y) + \"p.mp4\"\n",
         "!rm -f image-*.png *.mp4\n",
         "!echo -e \"\\e[36;1m[pdftoppm]\\e[0m $pdf_file_name -> image-*.png $output_resolution_xy\"\n",
-        "!pdftoppm -scale-to-x -1 -scale-to-y $output_resolution_y -png \"$pdf_file_name\" image\n",
+        "!pdftoppm -scale-to-x -1 -scale-to-y $output_resolution_y -progress -png \"$pdf_file_name\" image\n",
         "!echo -e \"\\e[36;1m[ffmpeg]\\e[0m image-*.png -> $mp4_file_name\"\n",
-        "!ffmpeg -y -pattern_type glob -r 1/2 -i \"image-*.png\" -vf \"crop=min(ih*16/9\\,iw):ih,scale=-2:$output_resolution_y:flags=lanczos,pad=x=-2:aspect=16/9\" -c:v libx264 -r 30 -pix_fmt yuv420p -bf 0 \"$mp4_file_name\""
+        "!ffmpeg -y -pattern_type glob -r 1/2 -i \"image-*.png\" -vf \"crop=min(ih*16/9\\,iw):ih,scale=-2:$output_resolution_y:flags=lanczos,pad=x=-2:aspect=16/9\" -c:v libx264 -r 30 -pix_fmt yuv420p -bf 0 -force_key_frames \"expr:gte(t,n_forced*2)\" \"$mp4_file_name\""
       ],
       "metadata": {
         "id": "X5_YlHOgeLIY",

--- a/colab/vrc_lt_converter.ipynb
+++ b/colab/vrc_lt_converter.ipynb
@@ -99,7 +99,7 @@
         "!echo -e \"\\e[36;1m[pdftoppm]\\e[0m $pdf_file_name -> image-*.png $output_resolution_xy\"\n",
         "!pdftoppm -scale-to-x -1 -scale-to-y $output_resolution_y -progress -png \"$pdf_file_name\" image\n",
         "!echo -e \"\\e[36;1m[ffmpeg]\\e[0m image-*.png -> $mp4_file_name\"\n",
-        "!ffmpeg -y -pattern_type glob -r 1/2 -i \"image-*.png\" -vf \"crop=min(ih*16/9\\,iw):ih,scale=-2:$output_resolution_y:flags=lanczos,pad=x=-2:aspect=16/9\" -c:v libx264 -r 30 -pix_fmt yuv420p -bf 0 -force_key_frames \"expr:gte(t,n_forced*2)\" \"$mp4_file_name\""
+        "!ffmpeg -y -pattern_type glob -r 1/2 -i \"image-*.png\" -vf \"crop=min(ih*16/9\\,iw):ih,scale=-2:$output_resolution_y:flags=lanczos,pad=x=-2:aspect=16/9\" -c:v libx264 -r 30 -pix_fmt yuv420p -bf 0 -force_key_frames \"expr:gte(t,n_forced)\" \"$mp4_file_name\""
       ],
       "metadata": {
         "id": "X5_YlHOgeLIY",

--- a/colab/vrc_lt_converter.ipynb
+++ b/colab/vrc_lt_converter.ipynb
@@ -99,7 +99,7 @@
         "!echo -e \"\\e[36;1m[pdftoppm]\\e[0m $pdf_file_name -> image-*.png $output_resolution_xy\"\n",
         "!pdftoppm -scale-to-x -1 -scale-to-y $output_resolution_y -png \"$pdf_file_name\" image\n",
         "!echo -e \"\\e[36;1m[ffmpeg]\\e[0m image-*.png -> $mp4_file_name\"\n",
-        "!ffmpeg -y -pattern_type glob -r 1/2 -i \"image-*.png\" -vf \"crop=min(ih*16/9\\,iw):ih,scale=-2:$output_resolution_y:flags=lanczos,pad=x=-2:aspect=16/9\" -c:v libx264 -r 30 -pix_fmt yuv420p \"$mp4_file_name\""
+        "!ffmpeg -y -pattern_type glob -r 1/2 -i \"image-*.png\" -vf \"crop=min(ih*16/9\\,iw):ih,scale=-2:$output_resolution_y:flags=lanczos,pad=x=-2:aspect=16/9\" -c:v libx264 -r 30 -pix_fmt yuv420p -bf 0 \"$mp4_file_name\""
       ],
       "metadata": {
         "id": "X5_YlHOgeLIY",


### PR DESCRIPTION
- pdfからの画像取り出し時に途中経過を表示します (`-progress`)。
- 動画エンコードにおいて、Bフレームの使用を抑制します (`-bf 0`)。
- 動画エンコードにおいて、~~2秒~~1秒おきにキーフレーム (Iフレーム) を強制します (`-force_key_frames \"expr:gte(t,n_forced)\"`)。
